### PR TITLE
Use gdown instead of downloader

### DIFF
--- a/download_TrackingNet.py
+++ b/download_TrackingNet.py
@@ -3,7 +3,7 @@ import pandas as pd
 from tqdm import tqdm
 import argparse
 
-import downloader
+import gdown
 
 
 
@@ -37,11 +37,7 @@ def main(trackingnet_dir="TrackingNet", csv_dir=".", overwrite=False, chunks=[],
 				destination_path = os.path.join(trackingnet_dir, chunk_folder, datum.lower(), Google_drive_file_name)
 
 				if (not os.path.exists(destination_path)): 
-
-					downloader.download(url='https://drive.google.com/uc?id={id}'.format(id=Google_drive_file_id),
-						output=destination_path,
-						quiet=True,
-					)
+					gdown.download(url=f'https://drive.google.com/uc?id={Google_drive_file_id}', output=destination_path, quiet=True)
 
 
 


### PR DESCRIPTION
This adds a dependency on [`gdown`](https://pypi.org/project/gdown/), but I found it much more stable than using the downloader.py used here. With downloader.py, I constantly received the error noted in the readme, despite repeated attempts ("Maybe you need to change permission over 'Anyone with the link'?")